### PR TITLE
Remove Test Ruby PDX slide

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,16 +151,6 @@
           <p>Join here: <a href="https://pdxruby-slack.herokuapp.com/">pdxruby-slack.herokuapp.com</a></p>
         </section>
         <section>
-          <h2>Test Ruby PDX Monthly Meeting</h2>
-          <p>
-            Test Ruby PDX is a user group focusing on testing from a developer's perspective. Join us for peer mentoring, conversation,
-            and pizza at 6, followed by presentations at 7.
-          </p>
-          <h3>For more information about this and future meetings, follow @TestRubyPDX on Twitter.</h3>
-          <p>Renew Financial, 402 SW 6th Ave, 8th floor</p>
-          <p><a href="http://testrubypdx.org/">testrubypdx.org</a></p>
-        </section>
-        <section>
           <h2>MotionPDX Meeting</h2>
           <p>
             RubyMotion lets you quickly develop cross-platform native apps for iOS, Android and OS X, all using your favorite editor and the awesome Ruby language you know and love. Join us for presentations, demos, discussions, and help getting started with RubyMotion. We are also on slack <a href="https://motioneers.herokuapp.com/">https://motioneers.herokuapp.com/</a>.


### PR DESCRIPTION
I *believe* this is no longer functional, or on hiatus. In any case, the
website is no longer active, so probably best to remove for now.