### PR TITLE
Remove coworking

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,10 +111,6 @@
               <strong>Ruby Lunch — Last Wednesdays</strong>
               <p>Hang out and eat lunch with your fellow Ruby enthusiasts.</p>
             </li>
-            <li>
-              <strong>Ruby Coworking - Thursdays at Crema in SE (Check Calagator for confirmation)</strong>
-              <p>An informal gathering of Ruby/Rails developers, working alongside each other.</p>
-            </li>
           </ul>
         </section>
         <section>


### PR DESCRIPTION
Coworking has been on hiatus - we can always revert this if this
changes but probably best to remove for now.