### PR TITLE
Comment-out slide for MotionPDX (RubyMotion Meetup)

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,15 +142,15 @@
           <h3>✨  PDX Ruby Slack ✨ </h3>
           <p>Join here: <a href="https://pdxruby-slack.herokuapp.com/">pdxruby-slack.herokuapp.com</a></p>
         </section>
-        <section>
+        <!-- <section>
           <p><img src="content/rubymotion-logo.png" alt="RubyMotion logo"></p>
           <h2>RubyMotion Meetup</h2>
           <p>
             Join us to learn how to build native iOS, Android, and Mac apps using the awesome Ruby language you know and love. Beginners welcome!
           </p>
           <h3>Every Second Wednesday</h3>
-          <p><a href="http://www.meetup.com/MotionPDX/">http://www.meetup.com/MotionPDX/</a></p>
-        </section>
+          <p><a href="http://meetup.rubymotion.com">http://meetup.rubymotion.com</a></p>
+        </section> -->
         <!-- <section>
           <h2>Learn Ruby PDX</h2>
           <p>


### PR DESCRIPTION
So...we decided not to renew our paid Meetup.com subscription, which means the link on our slide needed to be updated to our new website (http://meetup.rubymotion.com). However, we've also sort of transitioned into being an exclusively online meetup and have become the official meetup of the RubyMotion community. Our RubyMotion Meetup is certainly not dead, but we're not really meeting in-person in Portland anymore. I still think our meetup would be beneficial to Portland Rubyists. However, It didn't seem appropriate to advertise our meetup since it's not exclusively Portland anymore, so I've commented out our slide.

Let me know if you have any alternative ideas.